### PR TITLE
Changes for the scheduling interval feature

### DIFF
--- a/courier/management/commands/create_daily_schedule.py
+++ b/courier/management/commands/create_daily_schedule.py
@@ -3,74 +3,75 @@ from django.utils import timezone
 from django.utils.timezone import make_aware
 from django.utils.timezone import get_current_timezone
 import random
-from random import shuffle
 import datetime
 from datetime import date
 import math
 from courier.models import UserSendTime
 from fuauth.models import User
 
-all_users = User.objects.all()
+
+all_users = User.objects.filter(interval_type = User.PER_DAY,
+            receiving_messages=True, is_active=True)
 group_a = []
 group_b = []
 group_c = []
 
 def divide_users(group_a, group_b, group_c):
-  num_of_users = len(all_users)
-  remainder_users = num_of_users%3
-  users_divided_by_three = math.floor(num_of_users/3)
-  group_a_total = int(users_divided_by_three)
-  group_b_total = int(users_divided_by_three)
-  group_c_total = int(users_divided_by_three) + remainder_users
-  group_b_range = group_a_total + group_b_total
-  group_c_range = group_b_range + group_c_total
-  users_list = list(all_users)
-  shuffle(users_list)
-  group_a = users_list[0:group_a_total]
-  group_b = users_list[group_a_total:group_b_range]
-  group_c = users_list[group_b_range:group_c_range]
-  return(group_a, group_b, group_c)
+    num_of_users = len(all_users)
+    remainder_users = num_of_users%3
+    users_divided_by_three = math.floor(num_of_users/3)
+    group_a_total = int(users_divided_by_three)
+    group_b_total = int(users_divided_by_three)
+    group_c_total = int(users_divided_by_three) + remainder_users
+    group_b_range = group_a_total + group_b_total
+    group_c_range = group_b_range + group_c_total
+    users_list = list(all_users)
+    random.shuffle(users_list)
+    group_a = users_list[0:group_a_total]
+    group_b = users_list[group_a_total:group_b_range]
+    group_c = users_list[group_b_range:group_c_range]
+    return(group_a, group_b, group_c)
 
 
 def create_schedule():
-  """
-  Creates 5 random send times
-  per day, within the hours of 6AM and 7PM PST. Send times 
-  are no closer together than 40 minutes and no farther apart than
-  2 hours and 36 minutes.
-  """
+    """
+    Creates 5 random send times
+    per day, within the hours of 6AM and 7PM PST. Send times 
+    are no closer together than 40 minutes and no farther apart than
+    2 hours and 36 minutes.
+    """
   
-  today = date.today()
-  day_start = make_aware(datetime.datetime(today.year, today.month, today.day,6,0,0,000000),get_current_timezone())
-  schedule = []
-  start_time = day_start
-  for x in range(0,5):
-    random_seconds = random.randint(2400, 9360)
-    send_time = start_time + datetime.timedelta(seconds=random_seconds)
-    schedule.append(send_time)
-    start_time = send_time
-  return schedule 
+    today = date.today()
+    day_start = make_aware(datetime.datetime(today.year, today.month, 
+                today.day,6,0,0,000000),get_current_timezone())
+    schedule = []
+    start_time = day_start
+    
+    for x in range(0,5):
+        random_seconds = random.randint(2400, 9360)
+        send_time = start_time + datetime.timedelta(seconds=random_seconds)
+        schedule.append(send_time)
+        start_time = send_time
+    
+    return schedule 
 
 def record_user_send_times(group):
-  """
-  Creates send times specific to each active user who has chosen to receive messages. 
-  Will reduce the number of send times created in create_schedule based on the 
-  number of texts the user has chosen to receive.
-
-  """
-  group_schedule = create_schedule()
-  shuffle(group_schedule)
-  for user in group:
-    if user.receiving_messages==True & user.is_active==True:
+    """
+    Creates send times specific to each active user who has chosen to receive messages. 
+    Will reduce the number of send times created in create_schedule based on the 
+    number of texts the user has chosen to receive.
+    """
+    group_schedule = create_schedule()
+    random.shuffle(group_schedule)
+    for user in group:
         user_schedule = group_schedule[0:int(user.how_many_messages)]
         for time in user_schedule:
-          user_send_time = UserSendTime.objects.create(scheduled_time = time, user = user)
-
+            user_send_time = UserSendTime.objects.create(scheduled_time = time, user = user)
 
 
 class Command(BaseCommand):
-  def handle(self, *args, **options):
-    group_q, group_r, group_s = divide_users(group_a, group_b, group_c)
-    record_user_send_times(group_q)
-    record_user_send_times(group_r)
-    record_user_send_times(group_s)
+    def handle(self, *args, **options):
+        group_q, group_r, group_s = divide_users(group_a, group_b, group_c)
+        record_user_send_times(group_q)
+        record_user_send_times(group_r)
+        record_user_send_times(group_s)

--- a/courier/management/commands/create_monthly_schedule.py
+++ b/courier/management/commands/create_monthly_schedule.py
@@ -29,6 +29,26 @@ DEFAULT_END_TIME = datetime.time(hour=19, tzinfo = DEFAULT_TIMEZONE)
 def get_user_datetimes(year, month, days_in_month, start_day, msg_count, 
                        start_time, end_time, timezone):
     '''
+    Derive times to schedule user for the current/following month,
+    randomly generated in the specified periods
+    
+    - year : int
+    - month : int
+    - days_in_month : int
+    - start_day : int
+        day of month to start (may be greater than 1)
+    - msg_count : int
+        Number of messages to schedule
+    - start_time : datetime.time
+        Earliest time of day to schedule
+    - end_time : datetime.time
+        Latest time of day to schedule
+    - timezone : django.util.timezone
+        Timezone to determine offset  
+        
+    return : list of datetimes                  
+     
+    
     the result days should be somewhat spread throughout the month
     no duplicate days per random.sample
     '''    
@@ -54,6 +74,8 @@ def month_to_schedule(now):
     if the current date has day >= 10 or the current month if day < 10,
     otherwise it won't schedule times.
     
+    - now : datetime
+    
     returns year, month, count of days in month, day to start scheduling (all ints)
     '''
     
@@ -76,6 +98,10 @@ def month_to_schedule(now):
             
             
 def schedule_users():
+    '''
+    Add scheduled messages to UserSendTime for each active user receiving 
+    FiveUp messages on the monthly plan.
+    '''
     users = User.objects.filter(interval_type=User.PER_MONTH,
             receiving_messages=True, is_active=True)  
              
@@ -90,8 +116,9 @@ def schedule_users():
         for t in times:
             UserSendTime.objects.create(scheduled_time = t, user = user)
     ''' 
-    # when the User class has fields to indicate individual start and end times
-    # use the following instead. Will need to validate user times and convert timezone 
+    When the User class has fields to indicate individual start and end times
+    use the following instead. Will need to validate user times and convert timezone 
+    
     for user in users:
         times = get_user_datetimes(days_in_month, int(user.how_many_messages), 
                 user.start_time, user.end_time, CONVERT_ME(user.timezone))       

--- a/courier/management/commands/create_monthly_schedule.py
+++ b/courier/management/commands/create_monthly_schedule.py
@@ -1,0 +1,105 @@
+'''
+Schedule messages for users who have chosen to received messages PER_MONTH
+
+Issues:  
+
+currently using the default start and end times of day
+currently using the django current timezone
+code structured to facilitate switch to individual User attributes
+
+The date when this module is run determines which month is scheduled.  
+see function: month_to_schedule
+
+Care should be taken not to run in the first or last hours of a month
+to avoid Daylight Savings Time issues.
+'''         
+  
+from django.core.management.base import BaseCommand
+import django.utils.timezone as djtz
+from courier.models import UserSendTime
+from fuauth.models import User
+import calendar
+import datetime
+import random
+             
+DEFAULT_TIMEZONE = djtz.get_current_timezone()            
+DEFAULT_START_TIME = datetime.time(hour=9, tzinfo = DEFAULT_TIMEZONE)  
+DEFAULT_END_TIME = datetime.time(hour=19, tzinfo = DEFAULT_TIMEZONE)          
+            
+def get_user_datetimes(year, month, days_in_month, start_day, msg_count, 
+                       start_time, end_time, timezone):
+    '''
+    the result days should be somewhat spread throughout the month
+    no duplicate days per random.sample
+    '''    
+    times = []   
+    days = sorted(random.sample(range(start_day, days_in_month + 1), msg_count))
+    
+    for d in days:
+        start_secs = 3600 * start_time.hour + 60 * start_time.minute 
+        end_secs = 3600 * end_time.hour + 60 * end_time.minute
+        
+        times.append(djtz.make_aware(datetime.datetime(year, month, d),
+            djtz.get_current_timezone())
+            + datetime.timedelta(seconds=random.randint(start_secs, end_secs)))
+                   
+    return times
+    
+    
+def month_to_schedule(now):
+    '''
+    The date when this module is run determines which month
+    is scheduled.  This could be the month before or very early in the
+    current month.  Solution below is to schedule the next month
+    if the current date has day >= 10 or the current month if day < 10,
+    otherwise it won't schedule times.
+    
+    returns year, month, count of days in month, day to start scheduling (all ints)
+    '''
+    
+    year = now.year
+    month = now.month
+    
+    if now.day >= 10:
+        if now.month == 12:
+            year = now.year + 1
+            month = 1
+        else:    
+            month = now.month + 1
+        
+    days_in_month = calendar.monthrange(year, month)[1] 
+    
+    #if scheduling after start of month, don't schedule before 'now'
+    start_day = now.day if now.day < 10 else 1    
+
+    return year, month, days_in_month, start_day   
+            
+            
+def schedule_users():
+    users = User.objects.filter(interval_type=User.PER_MONTH,
+            receiving_messages=True, is_active=True)  
+             
+    now = datetime.datetime.now() 
+    year, month, days_in_month, start_day =  month_to_schedule(now)
+
+    #using the default times for all users
+    for user in users:
+        times = get_user_datetimes(year, month, days_in_month, 
+                start_day, int(user.how_many_messages), 
+                DEFAULT_START_TIME, DEFAULT_END_TIME, DEFAULT_TIMEZONE)       
+        for t in times:
+            UserSendTime.objects.create(scheduled_time = t, user = user)
+    ''' 
+    # when the User class has fields to indicate individual start and end times
+    # use the following instead. Will need to validate user times and convert timezone 
+    for user in users:
+        times = get_user_datetimes(days_in_month, int(user.how_many_messages), 
+                user.start_time, user.end_time, CONVERT_ME(user.timezone))       
+        for t in times:
+            UserSendTime.objects.create(scheduled_time = t, user = user)
+    ''' 
+            
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        schedule_users()

--- a/courier/management/commands/create_weekly_schedule.py
+++ b/courier/management/commands/create_weekly_schedule.py
@@ -1,0 +1,86 @@
+'''
+Schedule messages for users who have chosen to received messages PER_WEEK
+Schedule is always for the following week, first day is Monday (0)
+
+Issues:  
+
+currently using the default start and end times of day
+currently using the django current timezone
+code structured to facilitate switch to individual User attributes
+
+The date when this module is run determines which week is scheduled.  
+
+Care should be taken not to run in the first or last hours of a month
+to avoid Daylight Savings Time issues.
+'''         
+  
+from django.core.management.base import BaseCommand
+import django.utils.timezone as djtz
+from courier.models import UserSendTime
+from fuauth.models import User
+import datetime
+import random
+             
+DEFAULT_TIMEZONE = djtz.get_current_timezone()            
+DEFAULT_START_TIME = datetime.time(hour=9, tzinfo = DEFAULT_TIMEZONE)  
+DEFAULT_END_TIME = datetime.time(hour=19, tzinfo = DEFAULT_TIMEZONE)          
+            
+def get_user_datetimes(start_date, msg_count, start_time, end_time, timezone):
+    '''
+    the result days should be somewhat spread throughout the week
+    no duplicate days per random.sample
+    ''' 
+    
+    #validate msg_count
+    if msg_count > 6:
+        msg_count = 5
+    
+    dates = [start_date]
+    for i in range(6):
+        start_date += datetime.timedelta(days=1)
+        dates.append(start_date)
+    
+    dates = sorted(random.sample(dates, msg_count))
+       
+    times = []
+       
+    for d in dates:
+        start_secs = 3600 * start_time.hour + 60 * start_time.minute 
+        end_secs = 3600 * end_time.hour + 60 * end_time.minute
+        
+        #datetime.datetime(d.year, d.month, d.day),
+        times.append(djtz.make_aware(d, djtz.get_current_timezone())
+            + datetime.timedelta(seconds=random.randint(start_secs, end_secs)))
+                   
+    return times
+    
+                
+def schedule_users():
+    users = User.objects.filter(interval_type=User.PER_WEEK,
+            receiving_messages=True, is_active=True)  
+             
+    now = datetime.datetime.now() 
+    #truncate time elements
+    today = datetime.datetime(now.year, now.month, now.day)
+    start_date = today + datetime.timedelta(days= (7 - today.weekday()))
+
+    #using the default times for all users
+    for user in users:
+        times = get_user_datetimes(start_date, int(user.how_many_messages), 
+                DEFAULT_START_TIME, DEFAULT_END_TIME, DEFAULT_TIMEZONE)       
+        for t in times:
+            UserSendTime.objects.create(scheduled_time = t, user = user)
+    ''' 
+    # when the User class has fields to indicate individual start and end times
+    # use the following instead. Will need to validate user times and convert timezone 
+    for user in users:
+        times = get_user_datetimes(start_date, int(user.how_many_messages), 
+                user.start_time, user.end_time, CONVERT_ME(user.timezone))       
+        for t in times:
+            UserSendTime.objects.create(scheduled_time = t, user = user)
+    ''' 
+            
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        schedule_users()

--- a/courier/management/commands/create_weekly_schedule.py
+++ b/courier/management/commands/create_weekly_schedule.py
@@ -27,7 +27,23 @@ DEFAULT_END_TIME = datetime.time(hour=19, tzinfo = DEFAULT_TIMEZONE)
             
 def get_user_datetimes(start_date, msg_count, start_time, end_time, timezone):
     '''
-    the result days should be somewhat spread throughout the week
+    Derive times to schedule user for the current/following week,
+    randomly generated in the specified periods
+    
+    - start_date : datetime
+        Date of start of week to schedule
+    - msg_count : int
+        Number of messages to schedule
+    - start_time : datetime.time
+        Earliest time of day to schedule
+    - end_time : datetime.time
+        Latest time of day to schedule
+    - timezone : django.util.timezone
+        Timezone to determine offset  
+        
+    return : list of datetimes                  
+    
+    The result days should be somewhat spread throughout the week
     no duplicate days per random.sample
     ''' 
     
@@ -56,6 +72,10 @@ def get_user_datetimes(start_date, msg_count, start_time, end_time, timezone):
     
                 
 def schedule_users():
+    '''
+    Add scheduled messages to UserSendTime for each active user receiving 
+    FiveUp messages on the weekly plan.
+    '''
     users = User.objects.filter(interval_type=User.PER_WEEK,
             receiving_messages=True, is_active=True)  
              
@@ -71,8 +91,10 @@ def schedule_users():
         for t in times:
             UserSendTime.objects.create(scheduled_time = t, user = user)
     ''' 
-    # when the User class has fields to indicate individual start and end times
-    # use the following instead. Will need to validate user times and convert timezone 
+    When the User class has fields to indicate individual start and end times
+    use the following instead. 
+    Will need to validate user times and convert timezone
+     
     for user in users:
         times = get_user_datetimes(start_date, int(user.how_many_messages), 
                 user.start_time, user.end_time, CONVERT_ME(user.timezone))       

--- a/fuauth/admin.py
+++ b/fuauth/admin.py
@@ -17,12 +17,13 @@ class CustomUserAdmin(admin.ModelAdmin):
     fieldsets = (
         (None, {'fields': ('email', 'password', 'receive_newsletter')}),
         ('Personal info', {'fields': ('name', 'phone_number', 'carrier', 'user_timezone')}),
-        ('Permissions', {'fields': ('is_active', 'is_staff', 'is_superuser', 'receiving_messages', 'how_many_messages')}),
+        ('Permissions', {'fields': ('is_active', 'is_staff', 'is_superuser',
+            'receiving_messages', 'how_many_messages', 'interval_type')}),
         ('Auto info', {'fields': ('date_joined', 'uuid')}),
     )
 
-    list_display = ('email', 'name', 'phone_number', 'receiving_messages', 'how_many_messages', 
-        'date_joined', 'carrier')
+    list_display = ('email', 'name', 'phone_number', 'receiving_messages',
+        'how_many_messages', 'interval_type', 'date_joined', 'carrier')
     list_editable = ('receiving_messages',)
     list_filter = ('is_staff', 'is_superuser', 'is_active', 'groups',
         'receive_newsletter', 'receiving_messages', 'carrier')

--- a/fuauth/forms.py
+++ b/fuauth/forms.py
@@ -34,21 +34,24 @@ class PublicUserCreation(CreateView, ModelFormMixin): #AjaxTemplateMixin
     template_name = 'index.html'
     form_class = FUserCreationForm
     success_url = '/signup-success/'
-    fields = ['name', 'email', 'phone_number', 'carrier', 'how_many_messages', 'user_timezone', 'password']
+    fields = ['name', 'email', 'phone_number', 'carrier', 'how_many_messages', 
+              'user_timezone', 'interval_type', 'password']
     labels = {
         'name': _('what can we call you? Pete? Cindy?'),
         'email': _('what\'s your email address?'),
         'phone_number': _('phone number:'), 
         'carrier': _('your mobile carrier'),
-        'how_many_messages': _('how many fabulous messages do you want each day?'),
-        'user_timezone': _('your time zone')
+        'how_many_messages': _('how many fabulous messages do you want each scheduling interval?'),
+        'user_timezone': _('your time zone'),
+        'interval_type': _('scheduling interval for selected number of messages')
     }
 
 class FiveUUserChangeForm(UpdateView):
 
     template_name = 'profile_change.html'
     model = User
-    fields = ['phone_number', 'carrier', 'user_timezone', 'receiving_messages', 'how_many_messages']
+    fields = ['phone_number', 'carrier', 'user_timezone', 'receiving_messages', 
+              'how_many_messages', 'interval_type']
     success_url = "/login/"
 
 

--- a/fuauth/models.py
+++ b/fuauth/models.py
@@ -16,13 +16,14 @@ from uuidfield import UUIDField
 
 class UserManager(BaseUserManager):
   def _create_user(self, name, email, password, phone_number, carrier, how_many_messages,
-   user_timezone, is_staff, is_superuser):
+   user_timezone, interval_type, is_staff, is_superuser):
     now = timezone.now()
     if not email:
       raise ValueError(_('Hey there! We need your email address.'))
     email = self.normalize_email(email)
     user = self.model(name=name, email=email, phone_number=phone_number, carrier=carrier,
       how_many_messages=how_many_messages,  user_timezone=user_timezone,
+      interval_type=interval_type,
       is_staff=is_staff, is_superuser=is_superuser, last_login=now, date_joined=now)
     user.set_password(password)
     user.save(using=self._db)
@@ -31,12 +32,12 @@ class UserManager(BaseUserManager):
   def create_user(self, name, phone_number,
     carrier, user_timezone, email=None, password=None):
     return self._create_user(name, email, password, phone_number,
-      carrier, how_many_messages, user_timezone, False, False)
+      carrier, how_many_messages, user_timezone, interval_type, False, False)
 
   def create_superuser(self, name, email, password, phone_number,
     carrier, user_timezone):
     user=self._create_user(name, email, password, phone_number, carrier, how_many_messages,
-      user_timezone, True, True)
+      user_timezone, interval_type, True, True)
     user.is_active=True
     user.save(using=self._db)
     return user
@@ -97,6 +98,16 @@ class User(AbstractBaseUser, PermissionsMixin):
         (THREE, '3'),
         (FOUR, '4'),
         (FIVE, '5')
+    )
+
+    PER_DAY = 'Day'
+    PER_WEEK = 'Week'
+    PER_MONTH = 'Month'
+
+    INTERVAL_TYPE_CHOICES = (
+        (PER_DAY, 'Day'),
+        (PER_WEEK, 'Week'),
+        (PER_MONTH, 'Month')
     )
 
     name = models.CharField(
@@ -164,6 +175,12 @@ class User(AbstractBaseUser, PermissionsMixin):
       max_length=1,
       choices=HOW_MANY_MESSAGES_CHOICES,
       default=5
+    )
+
+    interval_type = models.CharField(
+      max_length=6,
+      choices=INTERVAL_TYPE_CHOICES,
+      default=PER_DAY
     )
 
     objects = UserManager()

--- a/messagebox/templates/profile_change.html
+++ b/messagebox/templates/profile_change.html
@@ -43,6 +43,12 @@
                 {{ form.how_many_messages|add_class:"form-control required" }}
 	            </div>
             </div>
+            <div class="form-group row">
+                <label class="col-sm-offset-2 col-sm-3 control-label">Schedule over the time interval:</label>
+                <div class="col-sm-4">
+                {{ form.interval_type|add_class:"form-control required" }}
+                </div>
+            </div>
 
             <div class="form-group">
 				<div class="col-sm-offset-5 col-sm-2">

--- a/messagebox/templates/registration/login.html
+++ b/messagebox/templates/registration/login.html
@@ -91,6 +91,12 @@
 				<div class="col-md-4"><p align="left">{{ user.how_many_messages }}</p></div>
 			</div>
 			<div class="row">
+				<div class="col-md-2">. </div>
+				<div class="col-md-4">. </div>
+				<div class="col-md-2"><p><b>Scheduling interval</b></p></div>
+				<div class="col-md-4"><p align="left">{{ user.interval_type }}</p></div>
+			</div>
+			<div class="row">
 				<div class="col-md-4"><h2><a href="/password_change" class="btn btn-default" role="button"><small>Change password</small></a></h2></div>
 			</div>
 		</div>


### PR DESCRIPTION
### Some descriptive notes on the changes for the new feature

  feature: scheduling intervals
  fork/branch: wlhays/FiveUp/sched_intervals

This new feature was tested under Python 3.6, Django 1.8 and SQLite3
  
  description:  add feature to have user specify scheduling interval for week and month in addition to day
                if week or month, then only one message per day
                
  new files: 
 
    courier/management/commands/create_monthly_schedule.py
    courier/management/commands/create_weekly_schedule.py

  Given that the "daily" script is run every day, the weekly and monthly scripts are more conventiently
  separate files that should be run in Heroku weekly and monthly, respectively
              
  changed files:

    courier/management/commands/create_daily_schedule.py
    * normalized indentation to 4 spaces from "mostly 2"
    * filtered users to have interval_type=PER_DAY
    * filtered users on initial pull from database for active and receiving_messages
    
    fuauth/admin.py, forms.py
    * add interval_type field to lists
    
    fuauth/models.py
    * add interval_type to lists
    * add INTERVAL_TYPE_CHOICES with values, etc
    * define interval_type field
    
I was getting errors when running this script, so changed to fixed values for how_many and interval_type:
  def create_superuser(self, name, email, password, phone_number,
    carrier, user_timezone):
    user=self._create_user(name, email, password, phone_number, carrier, 1,
         user_timezone, 'Day', True, True)
    user.is_active=True
    user.save(using=self._db)
    return user
    
    
    messagebox/templates/profile_change.html
    * add template for interval_type widget
 
 
    messagebox/templates/registration/login.html
    * add template for interval_type widget
  